### PR TITLE
Update Syntaxes/Diff.plist to recognize .rej files

### DIFF
--- a/Syntaxes/Diff.plist
+++ b/Syntaxes/Diff.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>diff</string>
 		<string>patch</string>
+		<string>rej</string>
 	</array>
 	<key>firstLineMatch</key>
 	<string>(?x)^


### PR DESCRIPTION
When using the command `git apply --reject *.patch`, rejected hunks that do not apply will be saved to a .rej file. This file just contains file diff hunks, so it would be useful for it to be syntax highlighted as such.
