### PR TITLE
Correct punctuation.definition.inserted.diff

### DIFF
--- a/Syntaxes/Diff.plist
+++ b/Syntaxes/Diff.plist
@@ -183,7 +183,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.inserted.diff</string>
+					<string>punctuation.definition.changed.diff</string>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -197,12 +197,12 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.inserted.diff</string>
+					<string>punctuation.definition.deleted.diff</string>
 				</dict>
 				<key>6</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.inserted.diff</string>
+					<string>punctuation.definition.deleted.diff</string>
 				</dict>
 			</dict>
 			<key>match</key>


### PR DESCRIPTION
It was added to all three of `markup.{inserted,changed,deleted}.diff`, which can cause unexpected highlighting if separate rules for the `punctuation.definition` are added.